### PR TITLE
Rename additional_swifftformat_args to additional_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ You can specify the `swiftformat` binary using the `binary_path` parameter:
 swiftformat.binary_path = "/path/to/swiftformat"
 ```
 
-You can specify additional `swiftformat` arguments using the `additional_swiftformat_args` parameter:
+You can specify additional `swiftformat` arguments using the `additional_args` parameter:
 
 ```ruby
-swiftformat.additional_swiftformat_args = "--indent tab --self insert"
+swiftformat.additional_args = "--indent tab --self insert"
 ```
 
 ## Development

--- a/lib/swiftformat/plugin.rb
+++ b/lib/swiftformat/plugin.rb
@@ -17,7 +17,7 @@ module Danger
     # Additional swiftformat command line arguments
     #
     # @return [String]
-    attr_accessor :additional_swiftformat_args
+    attr_accessor :additional_args
 
     # Runs swiftformat
     #
@@ -36,7 +36,7 @@ module Danger
       return if swift_files.empty?
 
       # Run swiftformat
-      results = swiftformat.check_format(swift_files, additional_swiftformat_args)
+      results = swiftformat.check_format(swift_files, additional_args)
 
       # Stop processing if the errors array is empty
       return if results[:errors].empty?

--- a/spec/swiftformat/plugin_spec.rb
+++ b/spec/swiftformat/plugin_spec.rb
@@ -31,8 +31,8 @@ module Danger
         end
       end
 
-      context "with additional_swiftformat_args" do
-        let(:additional_swiftformat_args) { "--indent tab --self insert" }
+      context "with additional_args" do
+        let(:additional_args) { "--indent tab --self insert" }
         let(:success_output) { { errors: [], stats: { run_time: "0.08s" } } }
 
         it "should pass the additional flags to swiftformat" do
@@ -41,10 +41,10 @@ module Danger
           allow(@sut.git).to receive(:deleted_files).and_return(["Deleted.swift"])
           allow_any_instance_of(SwiftFormat).to receive(:installed?).and_return(true)
           allow_any_instance_of(SwiftFormat).to receive(:check_format)
-            .with(%w(Added.swift Modified.swift), additional_swiftformat_args)
+            .with(%w(Added.swift Modified.swift), additional_args)
             .and_return(success_output)
 
-          @sut.additional_swiftformat_args = additional_swiftformat_args
+          @sut.additional_args = additional_args
 
           @sut.check_format(fail_on_error: true)
 


### PR DESCRIPTION
It simply reads better:

```diff
- swiftformat.additional_swiftformat_args = "--indent tab --self insert"
+ swiftformat.additional_args = "--indent tab --self insert"
```