### PR TITLE
Handle nil additional_args

### DIFF
--- a/lib/swiftformat/swiftformat.rb
+++ b/lib/swiftformat/swiftformat.rb
@@ -10,7 +10,7 @@ module Danger
 
     def check_format(files, additional_args = "")
       cmd = [@path] + files
-      cmd << additional_args.split unless additional_args.empty?
+      cmd << additional_args.split unless additional_args.nil? || additional_args.empty?
       cmd << %w(--dryrun --verbose)
       output = Cmd.run(cmd.flatten)
       raise "error running swiftformat: empty output" if output.empty?

--- a/spec/swiftformat/swiftformat_spec.rb
+++ b/spec/swiftformat/swiftformat_spec.rb
@@ -84,6 +84,21 @@ RSpec.describe Danger::SwiftFormat do
       expect { @sut.check_format(%w(.)) }.to raise_error("error running swiftformat: empty output")
     end
 
+    it "should support nil additional command line arguments" do
+      expect(@cmd).to receive(:run)
+        .with(%w(swiftformat . --dryrun --verbose))
+        .and_return(fixture("swiftformat_output.txt"))
+
+      output = {
+          errors: [],
+          stats: {
+              run_time: "0.08"
+          }
+      }
+
+      expect(@sut.check_format(%w(.), nil)).to eq(output)
+    end
+
     it "should support additional command line arguments" do
       expect(@cmd).to receive(:run)
         .with(%w(swiftformat . --self insert --indent tab --dryrun --verbose))


### PR DESCRIPTION
This would otherwise cause a crash when nil addition_args is provided:


```
2769
    Danger::DSLError: 
2770
    [!] Invalid `Dangerfile` file: undefined method `empty?' for nil:NilClass
2771
     #  from Dangerfile:42
2772
     #  -------------------------------------------
2773
     #  swiftformat.binary_path = "#{workspace.base_path}/vendor/swiftformat/swiftformat"
2774
     >  swiftformat.check_format(fail_on_error: true)
2775
     #  
2776
     #  -------------------------------------------
2777
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-swiftformat-0.1.0/lib/swiftformat/swiftformat.rb:13:in `check_format'
2778
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-swiftformat-0.1.0/lib/swiftformat/plugin.rb:39:in `check_format'
2779
      Dangerfile:42:in `block in parse'
2780
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/danger_core/dangerfile.rb:200:in `eval'
2781
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/danger_core/dangerfile.rb:200:in `block in parse'
2782
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/danger_core/dangerfile.rb:196:in `instance_eval'
2783
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/danger_core/dangerfile.rb:196:in `parse'
2784
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/danger_core/dangerfile.rb:273:in `run'
2785
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/danger_core/executor.rb:27:in `run'
2786
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/lib/danger/commands/runner.rb:66:in `run'
2787
      /Users/buddybuild/.gem/ruby/2.4.1/gems/claide-1.0.2/lib/claide/command.rb:334:in `run'
2788
      /Users/buddybuild/.gem/ruby/2.4.1/gems/danger-5.5.5/bin/danger:5:in `<top (required)>'
2789
      /Users/buddybuild/.gem/ruby/2.4.1/bin/danger:22:in `load'
2790
      /Users/buddybuild/.gem/ruby/2.4.1/bin/danger:22:in `<top (required)>'
```