### PR TITLE
Use shelljoin to allow spaces in file paths

### DIFF
--- a/lib/swiftformat/cmd.rb
+++ b/lib/swiftformat/cmd.rb
@@ -1,7 +1,7 @@
 module Danger
   class Cmd
     def self.run(cmd)
-      stdout, _stderr, _status = Open3.capture3(*cmd)
+      stdout, _stderr, _status = Open3.capture3(cmd.shelljoin)
 
       stdout.strip
     end

--- a/lib/swiftformat/plugin.rb
+++ b/lib/swiftformat/plugin.rb
@@ -63,7 +63,6 @@ module Danger
 
       files
         .select { |file| file.end_with?(".swift") }
-        .map { |file| Shellwords.escape(file) }
         .uniq
         .sort
     end


### PR DESCRIPTION
Files with spaces in the paths caused the swiftformat command to fail. I'm not sure if this is the best implementation since I'm fairly new to ruby