### PR TITLE
Improve output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     danger-swiftformat (0.3.3)
+      colorize (~> 0.7.7)
       danger-plugin-api (~> 1.0)
 
 GEM
@@ -17,9 +18,10 @@ GEM
       open4 (~> 1.3)
     coderay (1.1.2)
     colored2 (3.1.2)
+    colorize (0.7.7)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.5.7)
+    danger (5.6.4)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -34,13 +36,13 @@ GEM
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     diff-lcs (1.3)
-    faraday (0.14.0)
+    faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
     ffi (1.9.18)
     formatador (0.2.5)
-    git (1.3.0)
+    git (1.5.0)
     guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -55,7 +57,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    kramdown (1.16.2)
+    kramdown (1.17.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -69,7 +71,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.8.0)
+    octokit (4.10.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     parallel (1.12.1)
@@ -79,7 +81,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (12.3.0)
     rb-fsevent (0.10.2)
@@ -133,4 +135,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/danger-swiftformat.gemspec
+++ b/danger-swiftformat.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 
+  spec.add_runtime_dependency 'colorize', '~> 0.7.7'
+
   # General ruby development
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/lib/swiftformat/cmd.rb
+++ b/lib/swiftformat/cmd.rb
@@ -1,3 +1,4 @@
+require "colorize"
 require "shellwords"
 
 module Danger
@@ -5,7 +6,7 @@ module Danger
     def self.run(cmd)
       stdout, _stderr, _status = Open3.capture3(cmd.shelljoin)
 
-      stdout.strip
+      stdout.strip.uncolorize
     end
   end
 end

--- a/lib/swiftformat/plugin.rb
+++ b/lib/swiftformat/plugin.rb
@@ -46,7 +46,7 @@ module Danger
       message << "| File | Rules |\n"
       message << "| ---- | ----- |\n"
       results[:errors].each do |error|
-        message << "| #{error[:file]} | #{error[:rules].join(', ')} |\n"
+        message << "| #{error[:file].gsub(Dir.pwd + '/', '')} | #{error[:rules].join(', ')} |\n"
       end
       markdown message
 


### PR DESCRIPTION
Hi

This pull requests changes 2 things.

First, it removes escape characters used by `swiftformat` to colorize output, e.g. `�[0m` in this example:
![image](https://user-images.githubusercontent.com/350654/44435277-8f523c00-a5f2-11e8-94d7-5e7a6cd83b53.png)

Second change: it display file path related to working directory and not the absolute path.
Absolute path will contain information that's specific to build agent, for example:
`/usr/local/teamcity-agent/work/70cce8d068337448/path/to/AppDelegate.swift`.

The `/usr/local/teamcity-agent/work/70cce8d068337448` doesn't make much sense when displayed in GitHub.

So before:
<img width="757" alt="before" src="https://user-images.githubusercontent.com/350654/44435483-89a92600-a5f3-11e8-9831-c2b5a2ae6fcb.png">

After:
<img width="741" alt="aftertmp" src="https://user-images.githubusercontent.com/350654/44435752-bb6ebc80-a5f4-11e8-84fe-61ada95ebee4.png">

