### PR TITLE
Adds compatibility to SwiftFormat 0.37

### DIFF
--- a/lib/swiftformat/cmd.rb
+++ b/lib/swiftformat/cmd.rb
@@ -4,9 +4,7 @@ require "shellwords"
 module Danger
   class Cmd
     def self.run(cmd)
-      stdout, _stderr, _status = Open3.capture3(cmd.shelljoin)
-
-      stdout.strip.no_color
+      Open3.capture3(cmd.shelljoin)
     end
   end
 end

--- a/lib/swiftformat/swiftformat.rb
+++ b/lib/swiftformat/swiftformat.rb
@@ -14,9 +14,12 @@ module Danger
       cmd = [@path] + files
       cmd << additional_args.split unless additional_args.nil? || additional_args.empty?
       cmd << %w(--dryrun --verbose)
-      output = Cmd.run(cmd.flatten)
-      raise "error running swiftformat: empty output" if output.empty?
+      stdout, stderr, status = Cmd.run(cmd.flatten)
 
+      output = stdout.strip.no_color
+      output = stderr.strip.no_color if output.empty?
+
+      raise "Error running SwiftFormat:\nError: #{output}" unless status.success?
       process(output)
     end
 


### PR DESCRIPTION
SwiftFormat writes to stderr instead of stdout. This PR checks both outputs and takes the one which is not empty.

- Uses exit code to determine success or failure
- Improves output