### PR TITLE
Providing files

### DIFF
--- a/lib/swiftformat/cmd.rb
+++ b/lib/swiftformat/cmd.rb
@@ -4,9 +4,7 @@ require "shellwords"
 module Danger
   class Cmd
     def self.run(cmd)
-      stdout, _stderr, _status = Open3.capture3(cmd.shelljoin)
-
-      stdout.strip.no_color
+      Open3.capture3(cmd.shelljoin)
     end
   end
 end

--- a/lib/swiftformat/plugin.rb
+++ b/lib/swiftformat/plugin.rb
@@ -19,6 +19,13 @@ module Danger
     # @return [String]
     attr_accessor :additional_args
 
+    # Paths to files on which SwiftFormat should executed.
+    # If empty, this plugin uses all added and modified 
+    # Swift files of this PR. 
+    #
+    # @return [Array<String]
+    attr_accessor :files
+
     # Runs swiftformat
     #
     # @param [Boolean] fail_on_error
@@ -30,7 +37,7 @@ module Danger
       raise "Could not find SwiftFormat executable" unless swiftformat.installed?
 
       # Find Swift files
-      swift_files = find_swift_files
+      swift_files = @files.nil? || @files.empty? ? find_swift_files : @files
 
       # Stop processing if there are no swift files
       return if swift_files.empty?

--- a/lib/swiftformat/swiftformat.rb
+++ b/lib/swiftformat/swiftformat.rb
@@ -14,9 +14,12 @@ module Danger
       cmd = [@path] + files
       cmd << additional_args.split unless additional_args.nil? || additional_args.empty?
       cmd << %w(--dryrun --verbose)
-      output = Cmd.run(cmd.flatten)
-      raise "error running swiftformat: empty output" if output.empty?
+      stdout, stderr, status = Cmd.run(cmd.flatten)
 
+      output = stdout.strip.no_color
+      output = stderr.strip.no_color if output.empty?
+
+      raise "Error running SwiftFormat:\nError: #{output}" unless status.success?
       process(output)
     end
 

--- a/lib/swiftformat/swiftformat.rb
+++ b/lib/swiftformat/swiftformat.rb
@@ -16,10 +16,17 @@ module Danger
       cmd << %w(--dryrun --verbose)
       stdout, stderr, status = Cmd.run(cmd.flatten)
 
-      output = stdout.strip.no_color
-      output = stderr.strip.no_color if output.empty?
+      output = stdout.empty? ? stderr : stdout
+      raise "Error running SwiftFormat: Empty output." unless output
 
-      raise "Error running SwiftFormat:\nError: #{output}" unless status.success?
+      output = output.strip.no_color
+
+      if status && !status.success?
+        raise "Error running SwiftFormat:\nError: #{output}"
+      else
+        raise "Error running SwiftFormat: Empty output." if output.empty?
+      end
+
       process(output)
     end
 

--- a/spec/swiftformat/plugin_spec.rb
+++ b/spec/swiftformat/plugin_spec.rb
@@ -54,6 +54,30 @@ module Danger
         end
       end
 
+      context "with files provided" do
+        let(:files) { ["Added.swift"] }
+        let(:success_output) { { errors: [], stats: { run_time: "0.08s" } } }
+
+        it "should pass the provided files to swiftformat" do
+          expect(@sut.git).not_to receive(:added_files)
+          expect(@sut.git).not_to receive(:modified_files)
+          expect(@sut.git).not_to receive(:deleted_files)
+          allow_any_instance_of(SwiftFormat).to receive(:installed?).and_return(true)
+          allow_any_instance_of(SwiftFormat).to receive(:check_format)
+            .with(%w(Added.swift), "")
+            .and_return(success_output)
+
+          @sut.files = files
+          @sut.additional_args = ""
+
+          @sut.check_format(fail_on_error: true)
+
+          status = @sut.status_report
+          expect(status[:errors]).to be_empty
+          expect(status[:markdowns]).to be_empty
+        end
+      end
+
       describe "#check_format" do
         let(:success_output) { { errors: [], stats: { run_time: "0.08s" } } }
         let(:error_output) { { errors: [{ file: "Modified.swift", rules: %w(firstRule secondRule) }], stats: { run_time: "0.16s" } } }

--- a/spec/swiftformat/swiftformat_spec.rb
+++ b/spec/swiftformat/swiftformat_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Danger::SwiftFormat do
         .with(%w(swiftformat . --dryrun --verbose))
         .and_return("")
 
-      expect { @sut.check_format(%w(.)) }.to raise_error("error running swiftformat: empty output")
+      expect { @sut.check_format(%w(.)) }.to raise_error("Error running SwiftFormat: Empty output.")
     end
 
     it "should support nil additional command line arguments" do


### PR DESCRIPTION
With this PR the user can explicitly provide the files to check with SwiftFormat. I needed this because we check our CocoaPod dependencies into Git and do not want them to be checked.

This PR is based on #13.