### PR TITLE
Add additional_message option.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -150,3 +150,7 @@ PercentLiteralDelimiters:
 
 Security/YAMLLoad:
   Enabled: false
+
+Metrics/ModuleLength:
+  Exclude:
+    - "**/*_spec.rb"

--- a/lib/swiftformat/plugin.rb
+++ b/lib/swiftformat/plugin.rb
@@ -19,6 +19,11 @@ module Danger
     # @return [String]
     attr_accessor :additional_args
 
+    # Additional message to be appended the report
+    #
+    # @return [String]
+    attr_accessor :additional_message
+
     # Runs swiftformat
     #
     # @param [Boolean] fail_on_error
@@ -48,6 +53,11 @@ module Danger
       results[:errors].each do |error|
         message << "| #{error[:file].gsub(Dir.pwd + '/', '')} | #{error[:rules].join(', ')} |\n"
       end
+
+      unless additional_message.nil?
+        message << "\n" << additional_message
+      end
+
       markdown message
 
       if fail_on_error

--- a/spec/swiftformat/plugin_spec.rb
+++ b/spec/swiftformat/plugin_spec.rb
@@ -54,6 +54,25 @@ module Danger
         end
       end
 
+      context "with additional_message" do
+        let(:additional_message) { "I'm the additional message." }
+        let(:error_output) { { errors: [{ file: "Modified.swift", rules: %w(firstRule secondRule) }], stats: { run_time: "0.16s" } } }
+
+        it "should include the additional message in the report" do
+          allow(@sut.git).to receive(:added_files).and_return(["Added.swift"])
+          allow(@sut.git).to receive(:modified_files).and_return(["Modified.swift"])
+          allow(@sut.git).to receive(:deleted_files).and_return(["Deleted.swift"])
+          allow_any_instance_of(SwiftFormat).to receive(:installed?).and_return(true)
+          allow_any_instance_of(SwiftFormat).to receive(:check_format).with(%w(Added.swift Modified.swift), nil).and_return(error_output)
+          @sut.additional_message = additional_message
+          @sut.check_format(fail_on_error: true)
+
+          status = @sut.status_report
+          markdown = status[:markdowns].first.message
+          expect(markdown).to include(additional_message)
+        end
+      end
+
       describe "#check_format" do
         let(:success_output) { { errors: [], stats: { run_time: "0.08s" } } }
         let(:error_output) { { errors: [{ file: "Modified.swift", rules: %w(firstRule secondRule) }], stats: { run_time: "0.16s" } } }


### PR DESCRIPTION
This option allows for additional contextual information to be included in the Danger report. We use this to instruct developers how to resolve formatting errors.