### PR TITLE
Fix ERRORS_REGEX and RUNTIME_REGEX for SwiftFormat > v0.43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install bundler:1.17.2
 
 rvm:
   - 2.3.8

--- a/lib/swiftformat/swiftformat.rb
+++ b/lib/swiftformat/swiftformat.rb
@@ -41,7 +41,7 @@ module Danger
       }
     end
 
-    ERRORS_REGEX = /rules applied:(.*)\n.*updated (.*)$/.freeze
+    ERRORS_REGEX = /Formatting\s(.*)\n-- rules applied:(.*)$/.freeze
 
     def errors(output)
       errors = []
@@ -49,14 +49,14 @@ module Danger
         next if match.count < 2
 
         errors << {
-            file: match[1],
-            rules: match[0].split(",").map(&:strip)
+            file: match[0],
+            rules: match[1].split(",").map(&:strip)
         }
       end
       errors
     end
 
-    RUNTIME_REGEX = /.*swiftformat completed.*(.+\..+)s/.freeze
+    RUNTIME_REGEX = /.*SwiftFormat completed.*(.+\..+)s/.freeze
 
     def run_time(output)
       if RUNTIME_REGEX.match(output)

--- a/spec/fixtures/swiftformat_output.txt
+++ b/spec/fixtures/swiftformat_output.txt
@@ -1,9 +1,11 @@
-running swiftformat...
-formatting /Users/garriguv/FirstClass.swift
+Running SwiftFormat...
+(dryrun mode - no files will be changed.)
+Formatting /Users/garriguv/FirstClass.swift
 -- no changes
-formatting /Users/garriguv/FileWithErrors.swift
+Formatting /Users/garriguv/FileWithErrors.swift
 -- no changes
-formatting /Users/garriguv/OtherFile.swift
+Formatting /Users/garriguv/OtherFile.swift
 -- no changes
 
-swiftformat completed. 0/3 files would have been updated in 0.08s
+SwiftFormat completed in 0.08s.
+0/3 files would have been formatted.

--- a/spec/fixtures/swiftformat_output_with_errors.txt
+++ b/spec/fixtures/swiftformat_output_with_errors.txt
@@ -1,10 +1,11 @@
-running swiftformat...
-formatting /Users/garriguv/FirstClass.swift
+Running SwiftFormat...
+(dryrun mode - no files will be changed.)
+Formatting /Users/garriguv/FirstClass.swift
 -- no changes
-formatting /Users/garriguv/FileWithErrors.swift
- -- rules applied: consecutiveBlankLines, spaceAroundParens, trailingSpace
-would have updated /Users/garriguv/FileWithErrors.swift
-formatting /Users/garriguv/OtherFile.swift
+Formatting /Users/garriguv/FileWithErrors.swift
+-- rules applied: consecutiveBlankLines, spaceAroundParens, trailingSpace
+Formatting /Users/garriguv/OtherFile.swift
 -- no changes
 
-swiftformat completed. 1/3 files would have been updated in 0.08s
+SwiftFormat completed in 0.08s.
+1/3 files would have been formatted.


### PR DESCRIPTION
This plugin stopped working on newer versions of SwiftFormat as described on #26. 

- Updated the ERRORS_REGEX and RUNTIME_REGEX to match the new output format
- Updated fixtures with the new output format
- Setting specific version on travis config