### PR TITLE
Working directory fix

### DIFF
--- a/lib/swiftformat/plugin.rb
+++ b/lib/swiftformat/plugin.rb
@@ -69,7 +69,8 @@ module Danger
         message << "| File | Rules |\n"
         message << "| ---- | ----- |\n"
         results[:errors].each do |error|
-          message << "| #{error[:file].gsub("#{Dir.pwd}/", '')} | #{error[:rules].join(', ')} |\n"
+          file_path = error[:file]
+          message << "| #{file_path} | #{error[:rules].join(', ')} |\n"
         end
 
         unless additional_message.nil?

--- a/lib/swiftformat/swiftformat.rb
+++ b/lib/swiftformat/swiftformat.rb
@@ -1,9 +1,11 @@
 require "logger"
+require "pathname"
 
 module Danger
   class SwiftFormat
     def initialize(path = nil)
       @path = path || "swiftformat"
+      @project_root = nil
     end
 
     def installed?
@@ -11,7 +13,16 @@ module Danger
     end
 
     def check_format(files, additional_args = "", swiftversion = "")
-      cmd = [@path] + files
+      @repo_root = `git rev-parse --show-toplevel`.strip
+      @current_dir = Dir.pwd
+
+      # Calculate the relative path from repo root to current directory
+      @current_dir_relative = Pathname.new(@current_dir).relative_path_from(Pathname.new(@repo_root)).to_s
+
+      # Adjust file paths to be relative to current working directory
+      adjusted_files = files.map { |file| adjust_file_path(file) }
+
+      cmd = [@path] + adjusted_files
       cmd << additional_args.split unless additional_args.nil? || additional_args.empty?
 
       unless swiftversion.nil? || swiftversion.empty?
@@ -38,6 +49,18 @@ module Danger
 
     private
 
+    def adjust_file_path(file)
+      # If file path starts with the current directory relative path, strip it
+      if @current_dir_relative && @current_dir_relative != "." && file.start_with?("#{@current_dir_relative}/")
+        file.sub("#{@current_dir_relative}/", "")
+      elsif @current_dir_relative && @current_dir_relative == "."
+        # We're at repo root, file paths are already correct
+        file
+      else
+        file
+      end
+    end
+
     def process(output)
       {
           errors: errors(output),
@@ -54,8 +77,38 @@ module Danger
       output.scan(ERRORS_REGEX) do |match|
         next if match.count < 2
 
+        file_path_with_coords = match[0]
+        parts = file_path_with_coords.match(/^(.+):(\d+):(\d+)$/)
+        if parts
+          file_path_only = parts[1]
+          line_num = parts[2]
+          col_num = parts[3]
+        else
+          file_path_only = file_path_with_coords
+          line_num = nil
+          col_num = nil
+        end
+
+        if File.absolute_path?(file_path_only)
+          relative_path = file_path_only
+
+          if @repo_root
+            begin
+              relative_path = Pathname.new(file_path_only).relative_path_from(Pathname.new(@repo_root)).to_s
+            rescue StandardError
+              # Unable to convert to relative path
+            end
+          end
+
+          if line_num && col_num
+            file_path_with_coords = "#{relative_path}:#{line_num}:#{col_num}"
+          else
+            file_path_with_coords = relative_path
+          end
+        end
+
         errors << {
-            file: match[0].sub("#{Dir.pwd}/", ""),
+            file: file_path_with_coords,
             rules: match[1].split(",").map(&:strip)
         }
       end


### PR DESCRIPTION
This PR fixes incorrect file path resolution when the plugin is executed from a project subdirectory rather than the repository root.

A common case is KMP monorepo setups, where the iOS project lives in an ios/ subdirectory.

Related Issue: https://github.com/garriguv/danger-ruby-swiftformat/issues/50